### PR TITLE
Increment lib and dependency versions; change default to remote pods.

### DIFF
--- a/EosioSwiftEcc.podspec
+++ b/EosioSwiftEcc.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'EosioSwiftEcc'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Elliptical Curve Cryptography (ECC) functions for EOSIO. '
   s.homepage         = 'https://github.com/EOSIO/eosio-swift-ecc'
   s.license          = { :type => 'MIT', :text => <<-LICENSE
@@ -39,5 +39,5 @@ Pod::Spec.new do |s|
 						                'ENABLE_BITCODE' => 'YES' }
 
   s.ios.dependency 'GRKOpenSSLFramework', '~> 1.0'
-  s.ios.dependency 'EosioSwift', '~> 0.0.1'
+  s.ios.dependency 'EosioSwift', '~> 0.0.2'
 end

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-using_local_pods = true
+using_local_pods = false
 
 unless using_local_pods
   source 'https://github.com/EOSIO/eosio-swift-pod-specs.git'
@@ -30,11 +30,11 @@ else
     target 'EosioSwiftEccTests' do
       inherit! :search_paths
       pod 'GRKOpenSSLFramework', '~> 1.0'
-      pod 'EosioSwift', '~> 0.0.1'
+      pod 'EosioSwift', '~> 0.0.2'
     end
 
     pod 'GRKOpenSSLFramework', '~> 1.0'
-    pod 'EosioSwift', '~> 0.0.1'
+    pod 'EosioSwift', '~> 0.0.2'
     pod 'SwiftLint'
  end
 end


### PR DESCRIPTION
Updates EosioSwiftECC version to 0.0.2.
Updates EosioSwift dependency to 0.0.2.
Now, by default, `pod install` will pull dependencies from our spec repo instead of relative local paths.