### PR TITLE
Changed to use version 1.0.2.19 of GRKOpenSSLFramework.

### DIFF
--- a/EosioSwiftEcc.podspec
+++ b/EosioSwiftEcc.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
 						                'SWIFT_COMPILATION_MODE' => 'wholemodule',
 						                'ENABLE_BITCODE' => 'YES' }
 
-  s.ios.dependency 'GRKOpenSSLFramework', '1.0.2.16'
+  s.ios.dependency 'GRKOpenSSLFramework', '1.0.2.19'
   s.ios.dependency 'EosioSwift', '~> 0.1.3'
 end

--- a/Podfile
+++ b/Podfile
@@ -12,11 +12,11 @@ if using_local_pods
 
     target 'EosioSwiftEccTests' do
       inherit! :search_paths
-      pod 'GRKOpenSSLFramework', '1.0.2.16'
+      pod 'GRKOpenSSLFramework', '1.0.2.19'
       pod 'EosioSwift', :path => '../eosio-swift'
     end
 
-    pod 'GRKOpenSSLFramework', '1.0.2.16'
+    pod 'GRKOpenSSLFramework', '1.0.2.19'
     pod 'EosioSwift', :path => '../eosio-swift'
     pod 'SwiftLint'
   end
@@ -27,11 +27,11 @@ else
 
     target 'EosioSwiftEccTests' do
       inherit! :search_paths
-      pod 'GRKOpenSSLFramework', '1.0.2.16'
+      pod 'GRKOpenSSLFramework', '1.0.2.19'
       pod 'EosioSwift', '~> 0.1.3'
     end
 
-    pod 'GRKOpenSSLFramework', '1.0.2.16'
+    pod 'GRKOpenSSLFramework', '1.0.2.19'
     pod 'EosioSwift', '~> 0.1.3'
     pod 'SwiftLint'
   end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - EosioSwift (0.1.3):
     - BigInt (~> 3.1)
     - PromiseKit (~> 6.8)
-  - GRKOpenSSLFramework (1.0.2.16)
+  - GRKOpenSSLFramework (1.0.2.19)
   - PromiseKit (6.11.0):
     - PromiseKit/CorePromise (= 6.11.0)
     - PromiseKit/Foundation (= 6.11.0)
@@ -19,7 +19,7 @@ PODS:
 
 DEPENDENCIES:
   - EosioSwift (~> 0.1.3)
-  - GRKOpenSSLFramework (= 1.0.2.16)
+  - GRKOpenSSLFramework (= 1.0.2.19)
   - SwiftLint
 
 SPEC REPOS:
@@ -34,11 +34,11 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   EosioSwift: 473d814ab06e684e34f23703379f83bb91827454
-  GRKOpenSSLFramework: 35944e317e6336b2944ad70b059d84db6b2d8532
+  GRKOpenSSLFramework: 4abc733a8fcbc37060619a86a54202d2938dd70e
   PromiseKit: e4863d06976e7dee5e41c04fc7371c16b3600292
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
 
-PODFILE CHECKSUM: 63b97c6b73a6c3c179084e989cc4b414bfd6f593
+PODFILE CHECKSUM: affd08037f237e8152ca997036013f2ea38abea1
 
 COCOAPODS: 1.8.3


### PR DESCRIPTION
Before bitcode was failing when generating a build for a consumer SDK app.  Now with Xcode 11.1 and this change we are able to export a build without a bitcode failure.

https://github.com/EOSIO/eosio-swift-ecc/issues/60
